### PR TITLE
feat: Add bats binary

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: main
+    assignees: ["brokenpip3"]

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/test-local-action-with-conditionals.yaml
+++ b/.github/workflows/test-local-action-with-conditionals.yaml
@@ -10,11 +10,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.10.0
-      - name: Setup Bats-libs
+      - name: Setup Bats and Bats libs
         uses: ./
         with:
           support-clean: "false"

--- a/.github/workflows/test-local-action-with-conditionals.yaml
+++ b/.github/workflows/test-local-action-with-conditionals.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Setup Bats and Bats libs
         uses: ./
         with:
+          bats-version: 1.9.0
           support-clean: "false"
           assert-clean: "false"
           detik-install: "true"

--- a/.github/workflows/test-local-action.yaml
+++ b/.github/workflows/test-local-action.yaml
@@ -10,11 +10,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.10.0
-      - name: Setup Bats-libs
+      - name: Setup Bats and Bats libs
         uses: ./
         with:
           support-clean: "false"
@@ -53,11 +49,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.10.0
-      - name: Setup Bats-libs
+      - name: Setup Bats and Bats libs
         uses: ./
         with:
           support-clean: "false"

--- a/.github/workflows/test-local-action.yaml
+++ b/.github/workflows/test-local-action.yaml
@@ -52,7 +52,6 @@ jobs:
       - name: Setup Bats and Bats libs
         uses: ./
         with:
-          bats-version: 1.9.0
           support-clean: "false"
           assert-clean: "false"
           detik-clean: "false"

--- a/.github/workflows/test-local-action.yaml
+++ b/.github/workflows/test-local-action.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Setup Bats and Bats libs
         uses: ./
         with:
+          bats-version: 1.9.0
           support-clean: "false"
           assert-clean: "false"
           detik-clean: "false"

--- a/.github/workflows/test-public-action.yaml
+++ b/.github/workflows/test-public-action.yaml
@@ -10,11 +10,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.10.0
-      - name: Setup Bats-libs
+      - name: Setup Bats and Bats-libs
         uses: brokenpip3/setup-bats-libs@main
         with:
           support-clean: "false"
@@ -51,11 +47,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.9.0
-      - name: Setup Bats-libs
+      - name: Setup Bats and Bats-libs
         uses: brokenpip3/setup-bats-libs@0.1.0
         with:
           support-clean: "false"

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
 # Setup Bats Libs
 
-GitHub Action to setup the four major [bats](https://github.com/bats-core/bats-core) libs:
+This GitHub Action installs [Bats](https://github.com/bats-core/bats-core) and the four major bats libraries:
 
 * [bats-support](https://github.com/bats-core/bats-support)
 * [bats-assert](https://github.com/bats-core/bats-assert)
 * [bats-detik](https://github.com/bats-core/bats-detik)
 * [bats-file](https://github.com/bats-core/bats-file)
 
-The action can be also instructed to select which libs that will be installed.
+The action can be also instructed to select which libraries to install.
 
 ## How to use it
-
-Can be used in duo with [setup-bats](https://github.com/mig4/setup-bats) action
-to setup all the bats libs you need for your CI jobs.
-
-An example:
 
 ``` yaml
 on: [push]
@@ -22,103 +17,62 @@ on: [push]
 jobs:
    my_test:
      runs-on: ubuntu-latest
-     name: Install Bats common libs
+     name: Install Bats and bats libs
      steps:
        - name: Checkout
          uses: actions/checkout@v2
-       - name: Setup BATS
-         uses: mig4/setup-bats@v1
-       - name: Setup Bats libs
-         uses: brokenpip3/setup-bats-libs@0.1.0
+       - name: Setup Bats and bats libs
+         uses: brokenpip3/setup-bats-libs@1.0.0
+```
 
+## Libraries Path
+
+For each of the Bats libraries, you can choose to install them in the default location (`/usr/lib/bats-<lib-name>`) or specify a custom path.
+
+For example, if you want to install `bats-support` in the `./test/bats-support` directory, you can configure it as follows:
+
+
+``` yaml
+# ...
+       - name: Setup Bats and Bats libs
+         uses: brokenpip3/setup-bats-libs@0.1.0
+         with:
+           support-path: ${{ github.workspace }}/test/bats-support
 ```
 
 ## Inputs
 
-The available inputs with their default values are provided below.
+| Key              | Default | Required | Description                                    |
+|------------------|---------|----------|------------------------------------------------|
+| bats-install     | `true`    | false    | Bats installation, cache supported              |
+| bats-version     | `latest`  | false    | Bats version   |
+| support-install  | `true`    | false    | Bats-support installation      |
+| support-version  | `0.3.0`   | false    | Bats-support version       |
+| support-path     | `/usr/lib/bats-support` | false | Bats-support path |
+| support-clean    | `true`    | false    | Bats-support: clean temp files                  |
+| assert-install   | `true`    | false    | Bats-assert installation      |
+| assert-version   | `2.1.0`   | false    | Bats-assert version         |
+| assert-path      | `/usr/lib/bats-assert` | false | Bats-assert path |
+| assert-clean     | `true`    | false    | Bats-assert: clean temp files                   |
+| detik-install    | `true`   | false    | Bats-detik installation        |
+| detik-version    | `1.2.0`   | false    | Bats-detik version        |
+| detik-path       | `/usr/lib/bats-detik` | false | Bats-detik path |
+| detik-clean      | `true`    | false    | Bats-detik: clean temp files                    |
+| file-install     | `true`    | false    | Bats-file installation     |
+| file-version     | `0.3.0`   | false    | Bats-file version            |
+| file-path        | `/usr/lib/bats-file` | false | Bats-file path   |
+| file-clean       | `true`    | false    | Bats-file: clean temp files                     |
 
-``` yaml
-# ...
-       - name: Setup Bats libs
-         uses: brokenpip3/setup-bats-libs@0.1.0
-         with:          
-           support-install: true
-           support-version: 0.3.0
-           support-path: /usr/lib/bats-support
-           assert-install: true
-           assert-version: 0.2.0
-           assert-path: /usr/lib/bats-assert
-           detik-install: true
-           detik-version: 1.1.0
-           detik-path: /usr/lib/bats-detik
-           file-install: true
-           file-version: 0.3.0
-           file-path: /usr/lib/bats-file
-```
+## TODO
 
-If you would like `bats-support` installed within the `./test/bats-support` directory, you
-can configure it as such:
+* [X] Add more tests
 
-``` yaml
-# ...
-       - name: Setup Bats libs
-         uses: brokenpip3/setup-bats-libs@0.1.0
-         with:          
-           support-path: ${{ github.workspace }}/test/bats-support
-```
+* [X] Add Bats binary
 
-### Bats-support
+* [X] Add cache for bats binary
 
-* `support-install`: Bats-support installation, default to true
-  * required: `false`
-  * default: `true`
+* [X] Better Readme
 
-* `support-version`: Bats-support version, default to latest
-  * required: `false`
-  * default: `0.3.0`
+* [ ] Remove sudo in case of bats libs installed in $HOME
 
-* `support-path`: Bats-support path
-  * required: `false`
-  * default: `/usr/lib/bats-support`
-
-### Bats-assert
-
-* `assert-install`: Bats-assert installation, default to true
-  * required: `false`
-  * default: `true`
-
-* `assert-version`: Bats-assert version, default to latest
-  * required: `false`
-  * default: `0.2.0`
-
-* `assert-path`: Bats-assert path
-  * required: `false`
-  * default: `/usr/lib/bats-assert`
-
-### Bats-detik
-
-* `detik-install`: Bats-detik installation, default to true
-  * required: `false`
-  * default: `true`
-
-* `detik-version`: Bats-detik version, default to latest
-  *  required: `false`
-  *  default: `1.1.0`
-
-* `detik-path`: Bats-detik path
-  * required: `false`
-  * default: `/usr/lib/bats-detik`
-
-### Bats-file
-
-* `file-install`: Bats-file installation, default to true
-  * required: `false`
-  * default: `true`
-
-* `file-version`: Bats-file version, default to latest
-  * required: `false`
-  * default: `0.3.0`
-
-* `file-path`: Bats-file path
-  * required: `false`
-  * default: `/usr/lib/bats-file`
+* [ ] Add cache for bats libs

--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
 
         # From https://github.com/fluxcd/flux2/blob/44d69d6fc0c353e79c1bad021a4aca135033bce8/action/action.yml#L35
         if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
-          VERSION=$(curl -fsSL ${URL}/releases/latest | grep tag_name | cut -d '"' -f 4)
+          VERSION=$(curl -fsSL https://api.github.com/repos/bats-core/bats-core/releases/latest | grep tag_name | cut -d '"' -f 4)
         fi
         [[ $VERSION = v* ]] && VERSION="${VERSION:1}"
 

--- a/action.yaml
+++ b/action.yaml
@@ -118,6 +118,9 @@ runs:
             ${LIBDIR}/$(basename ${fn})
         done
 
+        ls -l ${DESTDIR}
+        ls -l ${LIBDIR}
+
         install -Dm755 bin/bats "${DESTDIR}/bats"
 
         install -Dm755 lib/bats-core/* -t "${LIBDIR}"

--- a/action.yaml
+++ b/action.yaml
@@ -89,6 +89,7 @@ runs:
       shell: bash
       run: |
         # In $HOME to avoid sudo requirements that eventually will be removed for the library as well
+        set -x
         VERSION=${{ inputs.bats-version }}
         DESTDIR="$HOME/.local/bin"
         LIBDIR="$HOME/.local/share/bats"
@@ -105,6 +106,7 @@ runs:
         mkdir -p ${DESTDIR}
 
         curl -sL ${URL}/archive/refs/tags/v${VERSION}.tar.gz | tar xz -C ${TEMPDIR} --strip-components 1 && cd ${TEMPDIR}
+        set +x
 
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD

--- a/action.yaml
+++ b/action.yaml
@@ -119,8 +119,10 @@ runs:
         done
 
         ls -l ${DESTDIR}
+        ls -l $HOME/.local/
         ls -l ${LIBDIR}
 
+        cp bin/bats "${DESTDIR}/bats"
         install -Dm755 bin/bats "${DESTDIR}/bats"
 
         install -Dm755 lib/bats-core/* -t "${LIBDIR}"

--- a/action.yaml
+++ b/action.yaml
@@ -103,7 +103,7 @@ runs:
         [[ $VERSION = v* ]] && VERSION="${VERSION:1}"
 
         mkdir -p ${TEMPDIR}
-        sudo mkdir -p ${DESTDIR}/src/
+        sudo mkdir -p ${DESTDIR}
 
         curl -sL ${URL}/archive/refs/tags/v${VERSION}.tar.gz | tar xz -C ${TEMPDIR} --strip-components 1 && cd ${TEMPDIR}
 

--- a/action.yaml
+++ b/action.yaml
@@ -90,7 +90,9 @@ runs:
       if: inputs.bats-install == 'true'
       id: bats-cache
       with:
-        path: "$HOME/.local/share/bats"
+        path: |
+          ~/.local/share/bats
+          ~/.local/bin/bats
         key: ${{ runner.os }}-bats
     - name: "Download and install Bats"
       if: inputs.bats-install == 'true' && steps.bats-cache.outputs.cache-hit != 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -84,12 +84,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: "Download and install Bats"
+    # This action would be much easier if only matrix steps will be supported in a composite action
+    - name: "Set cache for Bats"
+      uses: actions/cache@v3
       if: inputs.bats-install == 'true'
+      id: bats-cache
+      with:
+        path: $HOME/.local/bin/bats
+        key: ${{ runner.os }}-${{ env.BATS_LIB_PATH }}-bats
+    - name: "Download and install Bats"
+      if: inputs.bats-install == 'true' && steps.bats-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         # In $HOME to avoid sudo requirements that eventually will be removed for the library as well
-        set -x
         VERSION=${{ inputs.bats-version }}
         DESTDIR="$HOME/.local/bin"
         LIBDIR="$HOME/.local/share/bats"
@@ -106,7 +113,6 @@ runs:
         mkdir -p ${DESTDIR}
 
         curl -sL ${URL}/archive/refs/tags/v${VERSION}.tar.gz | tar xz -C ${TEMPDIR} --strip-components 1 && cd ${TEMPDIR}
-        set +x
 
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD

--- a/action.yaml
+++ b/action.yaml
@@ -103,7 +103,7 @@ runs:
         [[ $VERSION = v* ]] && VERSION="${VERSION:1}"
 
         mkdir -p ${TEMPDIR}
-        sudo mkdir -p ${DESTDIR}
+        mkdir -p ${DESTDIR}
 
         curl -sL ${URL}/archive/refs/tags/v${VERSION}.tar.gz | tar xz -C ${TEMPDIR} --strip-components 1 && cd ${TEMPDIR}
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,10 +1,19 @@
-name: Setup Bats libs
-description: A GitHub Action for installing Bats-libs(support, assert, detik)
+name: Setup Bats and libs
+description: A GitHub Action for installing Bats and Bats-libs(support, assert, detik, file)
 author: Brokenpip3
 branding:
   color: yellow
   icon: command
 inputs:
+  # Bats binary
+  bats-install:
+    description: "Bats installation, default to true"
+    required: false
+    default: true
+  bats-version:
+    description: "Bats version, default to latest (1.10.0 atm)"
+    required: false
+    default: "1.10.0"
   # support
   support-install:
     description: "Bats-support installation, default to true"
@@ -76,6 +85,48 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: "Download and install Bats"
+      if: inputs.bats-install == 'true'
+      shell: bash
+      run: |
+        # In $HOME to avoid sudo requirements that eventually will be removed for the library as well
+        VERSION=${{ inputs.bats-version }}
+        DESTDIR="$HOME/.local/bin"
+        LIBDIR="$HOME/.local/share/bats"
+        TEMPDIR="/tmp/bats"
+        URL="https://github.com/bats-core/bats-core/"
+
+        # From https://github.com/fluxcd/flux2/blob/44d69d6fc0c353e79c1bad021a4aca135033bce8/action/action.yml#L35
+        if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
+          VERSION=$(curl -fsSL -H "Authorization: token ${TOKEN}" ${URL}/releases/latest | grep tag_name | cut -d '"' -f 4)
+        fi
+        [[ $VERSION = v* ]] && VERSION="${VERSION:1}"
+
+        mkdir -p ${TEMPDIR}
+        sudo mkdir -p ${DESTDIR}/src/
+
+        curl -sL ${URL}/archive/refs/tags/v${VERSION}.tar.gz | tar xz -C ${TEMPDIR} --strip-components 1 && cd ${TEMPDIR}
+
+        # Archlinux style, except that we are not in a fakeroot env
+        # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
+        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/'"${LIBDIR}"'|g' bin/bats
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/'"${LIBDIR}"'|g' libexec/bats-core/*
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/'"${LIBDIR}"'|g' lib/bats-core/*
+
+        for fn in libexec/bats-core/*; do
+          install -Dm755 ${fn} \
+            ${LIBDIR}/$(basename ${fn})
+        done
+
+        install -Dm755 bin/bats "${DESTDIR}/bats"
+
+        install -Dm755 lib/bats-core/* -t "${LIBDIR}"
+
+        echo "Bats v$VERSION installed in $DESTDIR"
+        rm -rf ${TEMPDIR} || exit 0
+
+        echo "$DESTDIR" >> "$GITHUB_PATH"
+
     - name: "Download and install Bats-support"
       if: inputs.support-install == 'true'
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -90,8 +90,8 @@ runs:
       if: inputs.bats-install == 'true'
       id: bats-cache
       with:
-        path: $HOME/.local/bin/bats
-        key: ${{ runner.os }}-${{ env.BATS_LIB_PATH }}-bats
+        path: "$HOME/.local/share/bats"
+        key: ${{ runner.os }}-bats
     - name: "Download and install Bats"
       if: inputs.bats-install == 'true' && steps.bats-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
 
         # From https://github.com/fluxcd/flux2/blob/44d69d6fc0c353e79c1bad021a4aca135033bce8/action/action.yml#L35
         if [[ -z "$VERSION" ]] || [[ "$VERSION" = "latest" ]]; then
-          VERSION=$(curl -fsSL -H "Authorization: token ${TOKEN}" ${URL}/releases/latest | grep tag_name | cut -d '"' -f 4)
+          VERSION=$(curl -fsSL ${URL}/releases/latest | grep tag_name | cut -d '"' -f 4)
         fi
         [[ $VERSION = v* ]] && VERSION="${VERSION:1}"
 

--- a/action.yaml
+++ b/action.yaml
@@ -109,7 +109,7 @@ runs:
 
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
-        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats|g' bin/bats
+        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats/bats|g' bin/bats
         sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' libexec/bats-core/*
         sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' lib/bats-core/*
 

--- a/action.yaml
+++ b/action.yaml
@@ -110,8 +110,8 @@ runs:
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
         sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats/bats|g' bin/bats
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' libexec/bats-core/*
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' lib/bats-core/*
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats/|g' libexec/bats-core/*
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats/|g' lib/bats-core/*
 
         for fn in libexec/bats-core/*; do
           install -Dm755 ${fn} \
@@ -122,7 +122,6 @@ runs:
         ls -l $HOME/.local/
         ls -l ${LIBDIR}
 
-        cp bin/bats "${DESTDIR}/bats"
         install -Dm755 bin/bats "${DESTDIR}/bats"
 
         install -Dm755 lib/bats-core/* -t "${LIBDIR}"

--- a/action.yaml
+++ b/action.yaml
@@ -109,9 +109,9 @@ runs:
 
         # Archlinux style, except that we are not in a fakeroot env
         # https://gitlab.archlinux.org/archlinux/packaging/packages/bash-bats/-/blob/main/PKGBUILD
-        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/'"${LIBDIR}"'|g' bin/bats
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/'"${LIBDIR}"'|g' libexec/bats-core/*
-        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/'"${LIBDIR}"'|g' lib/bats-core/*
+        sed -i 's|BATS_ROOT/libexec/bats-core/bats|BATS_ROOT/share/bats|g' bin/bats
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' libexec/bats-core/*
+        sed -i 's|BATS_ROOT/lib/bats-core/|BATS_ROOT/share/bats|g' lib/bats-core/*
 
         for fn in libexec/bats-core/*; do
           install -Dm755 ${fn} \
@@ -131,6 +131,7 @@ runs:
         rm -rf ${TEMPDIR} || exit 0
 
         echo "$DESTDIR" >> "$GITHUB_PATH"
+        echo "$GITHUB_PATH"
 
     - name: "Download and install Bats-support"
       if: inputs.support-install == 'true'

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,6 @@ inputs:
   bats-version:
     description: "Bats version, default to latest (1.10.0 atm)"
     required: false
-    default: "1.10.0"
   # support
   support-install:
     description: "Bats-support installation, default to true"
@@ -118,19 +117,13 @@ runs:
             ${LIBDIR}/$(basename ${fn})
         done
 
-        ls -l ${DESTDIR}
-        ls -l $HOME/.local/
-        ls -l ${LIBDIR}
-
         install -Dm755 bin/bats "${DESTDIR}/bats"
-
         install -Dm755 lib/bats-core/* -t "${LIBDIR}"
 
         echo "Bats v$VERSION installed in $DESTDIR"
         rm -rf ${TEMPDIR} || exit 0
 
         echo "$DESTDIR" >> "$GITHUB_PATH"
-        echo "$GITHUB_PATH"
 
     - name: "Download and install Bats-support"
       if: inputs.support-install == 'true'


### PR DESCRIPTION
Due to the node 12 deprecation in august the `mig4/setup-bats` cannot be used anymore.
This PR will add the bats binary along with the bats libraries.